### PR TITLE
Issue #128: Added functionality to save paths to hdrgen and dcrawemu binaries

### DIFF
--- a/binary_paths.json
+++ b/binary_paths.json
@@ -1,0 +1,1 @@
+{"hdrgenpath":"","dcrawemupath":""}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,12 @@ use pipeline::pipeline;
 mod query_os_platform;
 use query_os_platform::query_os_platform;
 
+mod read_binary_paths;
+use read_binary_paths::read_binary_paths;
+
+mod write_binary_paths;
+use write_binary_paths::write_binary_paths;
+
 // Command to get app's data directory
 mod get_default_output_path;
 use get_default_output_path::get_default_output_path;
@@ -28,6 +34,8 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             pipeline, 
             query_os_platform, 
+            read_binary_paths,
+            write_binary_paths,
             get_default_output_path, 
             save_config,
             get_saved_configs

--- a/src-tauri/src/read_binary_paths.rs
+++ b/src-tauri/src/read_binary_paths.rs
@@ -1,0 +1,41 @@
+use std::fs;
+use std::path::Path;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Serialize, Deserialize)]
+struct Paths {
+    hdrgenpath: String,
+    dcrawemupath: String
+}
+
+#[tauri::command]
+pub fn read_binary_paths(app_handle: tauri::AppHandle) -> Result<String, String> {
+    // Retrieved part of this code from https://github.com/tauri-apps/tauri/discussions/5557
+    let binding_result = app_handle.path_resolver().app_config_dir();
+    let binding = match binding_result {
+        Some(v) => v,
+        None => return Err("Error saving config".to_string()),
+    };
+
+    // Get suggested config directory for the app from Tauri
+    let app_config_dir_result = binding.to_str();
+    let app_config_dir = match app_config_dir_result {
+        Some(v) => v,
+        None => return Err("Error saving config".to_string()),
+    };
+
+    // Get full path to file where binaries are saved
+    let paths_file = Path::new(app_config_dir)
+        .join("binary_paths.json");
+    let file_path = match paths_file.to_str() {
+        Some(v) => v,
+        None => return Err(format!("Invalid UTF-8 in binary file path {:?}", paths_file)),
+    };
+
+    // Read binary paths
+    match fs::read_to_string(file_path) {
+        Ok(contents) => Ok(contents),
+        Err(_) => Ok("".to_string()),
+    }
+}

--- a/src-tauri/src/write_binary_paths.rs
+++ b/src-tauri/src/write_binary_paths.rs
@@ -1,0 +1,52 @@
+use std::fs;
+use std::path::Path;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct Paths {
+    hdrgenpath: String,
+    dcrawemupath: String
+}
+
+#[tauri::command]
+pub fn write_binary_paths(app_handle: tauri::AppHandle, hdrgenPath: String, dcrawEmuPath: String) -> Result<(), String> {
+    let new_paths = Paths { hdrgenpath: hdrgenPath, dcrawemupath: dcrawEmuPath};
+    let paths_string = match serde_json::to_string(&new_paths) {
+        Ok(v) => v,
+        Err(error) => return Err(format!("Error serializing JSON: {:?}", error)),
+    };
+
+    // Retrieved part of this code from https://github.com/tauri-apps/tauri/discussions/5557
+    let binding_result = app_handle.path_resolver().app_config_dir();
+    let binding = match binding_result {
+        Some(v) => v,
+        None => return Err("Error saving config".to_string()),
+    };
+
+    // Get suggested config directory for the app from Tauri
+    let app_config_dir_result = binding.to_str();
+    let app_config_dir = match app_config_dir_result {
+        Some(v) => v,
+        None => return Err("Error saving config".to_string()),
+    };
+
+    // Get full path to file where binaries are being saved
+    let paths_file = Path::new(app_config_dir)
+        .join("binary_paths.json");
+    let file_path = match paths_file.to_str() {
+        Some(v) => v,
+        None => return Err(format!("Invalid UTF-8 in binary file path {:?}", paths_file)),
+    };
+    // let dir = Path::new(app_config_dir)
+    //     .join("configurations")
+    //     .join(&config.name);
+    // if create_dir_all(&dir).is_err() {
+    //     return Err("Error saving config.".to_string());
+    // }
+    
+    // Write binary paths to file
+    match fs::write(file_path, paths_string) {
+        Ok(()) => Ok(()),
+        Err(error) => Err(format!("Error writing to file: {:?}", error)),
+    }
+}

--- a/src/app/navigation.tsx
+++ b/src/app/navigation.tsx
@@ -16,6 +16,8 @@ export default function Navigation({
   setConfig,
   settings,
   setSettings,
+  saveDisabled,
+  setSaveDisabled,
   handleSettingsChange,
   handleGenerateHDRImage,
 }: any) {
@@ -137,6 +139,8 @@ export default function Navigation({
             <Settings
               settings={settings}
               setSettings={setSettings}
+              saveDisabled={saveDisabled}
+              setSaveDisabled={setSaveDisabled}
               handleChange={handleSettingsChange}
               toggleDialog={() => setShowSettings(!showSettings)}
             />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,19 +29,23 @@ export default function Home() {
           radianceDefaultPath = "C:\\Radiance\\bin";
         }
 
-        // Update settings
+        // Get the saved paths to binaries and update settings
+        const contents = await invoke<string>("read_binary_paths", {});
+        let contentsObject;
+        if (contents) { contentsObject = JSON.parse(contents); }
+        else { contentsObject = {hdrgenpath: "", dcrawemupath: "" }; }
         setSettings({
           radiancePath: radianceDefaultPath,
-          hdrgenPath: "",
-          dcrawEmuPath: "",
+          hdrgenPath: contentsObject.hdrgenpath,
+          dcrawEmuPath: contentsObject.dcrawemupath,
           outputPath: await invoke("get_default_output_path") // queries backend for suggested place to store files
         });
+        if (!contentsObject.hdrgenpath || !contentsObject.dcrawemupath) 
+          { alert("Please enter the paths to the HDRGen and dcraw_emu binaries in the settings before generating HDR images."); }
       })
       .catch(() => {
         console.error;
       });
-
-    alert("Please enter the paths to the HDRGen and dcraw_emu binaries in the settings before generating HDR images.")
   }, []);
 
   // Holds the fisheye coordinates and view settings
@@ -81,10 +85,14 @@ export default function Home() {
     outputPath: "",
   });
 
+  // Used to disable the save button when no changes have been made to settings
+  const [saveDisabled, setSaveDisabled] = useState(true)
+
   const handleSettingsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const updatedSettings = JSON.parse(JSON.stringify(settings));
     updatedSettings[event.currentTarget.name] = event.currentTarget.value;
     setSettings(updatedSettings);
+    setSaveDisabled(false);
   };
 
   // Reset progress
@@ -222,6 +230,8 @@ export default function Home() {
           setConfig={setConfig}
           settings={settings}
           setSettings={setSettings}
+          saveDisabled={saveDisabled}
+          setSaveDisabled={setSaveDisabled}
           handleSettingsChange={handleSettingsChange}
           handleGenerateHDRImage={handleGenerateHDRImage}
         />

--- a/src/app/settings.tsx
+++ b/src/app/settings.tsx
@@ -1,8 +1,11 @@
 import { open } from "@tauri-apps/api/dialog";
+import { invoke } from "@tauri-apps/api/tauri";
 
 export default function Settings({
   settings,
   setSettings,
+  saveDisabled,
+  setSaveDisabled,
   handleChange,
   toggleDialog,
 }: any) {
@@ -24,6 +27,12 @@ export default function Settings({
     const updatedSettings = JSON.parse(JSON.stringify(settings));
     updatedSettings["outputPath"] = directory;
     setSettings(updatedSettings);
+  };
+
+  const savePaths = () => {
+    invoke("write_binary_paths", {hdrgenPath: settings.hdrgenPath, dcrawEmuPath: settings.dcrawEmuPath})
+      .catch(() => console.error ); 
+    setSaveDisabled(true);
   };
 
   return (
@@ -138,6 +147,15 @@ export default function Settings({
                   onClick={toggleDialog}
                 >
                   Close
+                </button>
+                <button
+                  type="button"
+                  id="save-button"
+                  className="bg-gray-300 hover:bg-gray-400 disabled:bg-gray-600 disabled:hover:bg-gray-600 text-gray-700 font-semibold py-1 px-2 border-gray-400 rounded"
+                  onClick={savePaths}
+                  disabled={saveDisabled}
+                >
+                  Save
                 </button>
                 <div className="pt-2"></div>
               </div>


### PR DESCRIPTION
Added two new Tauri commands, read and write file paths, to save the file paths to the hdrgen and dcrawemu binaries the user enters in the settings page. Errors should be handled gracefully and should not affect anything else; the default radiance path should always appear regardless of whether the user has any paths saved; the warning message telling the user that they need to add paths should appear only if there are no saved paths.